### PR TITLE
Migrate from celery to dramatiq

### DIFF
--- a/celery_app.py
+++ b/celery_app.py
@@ -1,8 +1,0 @@
-from celery import Celery
-
-
-celery = Celery(
-    "worker",
-    broker="redis://localhost:6379/0",
-    backend="redis://localhost:6379/0",
-)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,8 @@ async-asgi-testclient = "^1.4.11"
 pytest-asyncio = "^0.21.1"
 puremagic = "^1.28"
 python-multipart = "^0.0.12"
+dramatiq = {extras = ["watch"], version = "^1.17.1"}
+ua-parser = "^0.18.0"
 
 
 [build-system]

--- a/secrets-example.yaml
+++ b/secrets-example.yaml
@@ -5,8 +5,10 @@ service:
 postgresql:
   # Url to postgresql for main service process. Must be with asynchronous driver
   url: "postgresql+asyncpg://user:password@localhost:5432/database"
-  # Url to postgresql for celery process. Must be with synchronous driver
-  celery_url: "postgresql://user:password@localhost:5432/database"
+
+redis:
+  # Url to redis for dramatiq
+  url: "redis://localhost:6379/0"
 
 
 # S3 storage parameters

--- a/src/routes/auth/dependencies.py
+++ b/src/routes/auth/dependencies.py
@@ -29,14 +29,16 @@ password_incorrect = define_error("password-incorrect", "Password incorrect", 40
 
 
 def client_details(request: Request) -> ClientInfo:
+    agent = request.headers.get("User-Agent", None)
+
     if request.client:
-        return ClientInfo(request.client.host)
+        return ClientInfo(request.client.host, agent)
 
     if "x-forwarder-for" in request.headers:
-        return ClientInfo(request.headers["x-forwarder-for"])
+        return ClientInfo(request.headers["x-forwarder-for"], agent)
 
     if "x-real-ip" in request.headers:
-        return ClientInfo(request.headers["x-real-ip"])
+        return ClientInfo(request.headers["x-real-ip"], agent)
 
 
 @has_errors(email_occupied, nickname_occupied, default_role_not_exist)

--- a/src/routes/auth/route.py
+++ b/src/routes/auth/route.py
@@ -45,7 +45,7 @@ async def signin(
     client: ClientInfo = Depends(client_details),
 ):
     if client:
-        new_login.delay(user.id, client.host)
+        new_login.send(user.id, client.host, client.agent)
 
     return await service.create_token(session, user)
 

--- a/src/routes/auth/scheme.py
+++ b/src/routes/auth/scheme.py
@@ -39,3 +39,4 @@ SignInBody = SignInEmailBody | SignInNicknameBody
 @dataclass
 class ClientInfo:
     host: str
+    agent: str

--- a/src/routes/users/route.py
+++ b/src/routes/users/route.py
@@ -7,7 +7,7 @@ from src.routes.users import service
 from src.models import Token, User, Role
 from src.database import acquire_session
 from .scheme import UpdateUserBody, UpdateOtherUserBody
-from src.dependencies import require_token, require_permissions
+from src.dependencies import require_token, require_permissions, optional_token
 
 from .dependencies import (
     file_mime,
@@ -43,7 +43,7 @@ async def update_me(
     token: Token = Depends(require_token),
     session: AsyncSession = Depends(acquire_session),
 ):
-    return await service.update_user(session, token.owner, body)
+    return await service.update_user(session, token.owner, body, token.owner)
 
 
 @router.post(
@@ -102,9 +102,10 @@ async def update_user_role(
 async def update_user_info(
     body: UpdateOtherUserBody = Depends(validate_update_other_user),
     user: User = Depends(validate_user),
+    token: Token | None = Depends(optional_token),
     session: AsyncSession = Depends(acquire_session),
 ):
-    return await service.update_user(session, user, body)
+    return await service.update_user(session, user, body, token and token.owner)
 
 
 @router.post(

--- a/src/routes/users/scheme.py
+++ b/src/routes/users/scheme.py
@@ -18,7 +18,10 @@ class UpdateUserBody(SchemeModel):
     remove_description: bool = Field(False, description="Whether to remove description")
 
     @field_validator("nickname")
-    def validate_nickname(cls, v: str):
+    def validate_nickname(cls, v: str | None) -> str | None:
+        if v is None:
+            return None
+
         assert len(v) > 5, "Nickname length cannot be less than 5 characters"
 
         assert consists_of(

--- a/tasks.py
+++ b/tasks.py
@@ -1,29 +1,94 @@
-from functools import lru_cache
+import inspect
+from datetime import timedelta
+from functools import lru_cache, wraps, partial
 
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
+import dramatiq
+from sqlalchemy import select
+from sqlalchemy.orm import joinedload
+from ua_parser import user_agent_parser
+from dramatiq.brokers.redis import RedisBroker
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from config import settings
-from src.models import User
-from celery_app import celery
+
+broker = RedisBroker(url=settings.redis.url)
+broker.add_middleware(dramatiq.middleware.asyncio.AsyncIO())
+dramatiq.set_broker(broker)
+write = partial(print, "[+]")
 
 
 @lru_cache(maxsize=-1)
 def init_db():
-    engine = create_engine(settings.postgresql.celery_url)
-    return sessionmaker(bind=engine, expire_on_commit=False)
+    from src.database import session_holder
+
+    session_holder.init(settings.postgresql.url)
+
+    return session_holder
 
 
-def get_session():
-    return init_db()()
+def get_session() -> AsyncSession:
+    return init_db().session()
 
 
-@celery.task()
-def new_login(user_id: int, address: str):
-    with get_session() as session:
-        user = session.get(User, user_id)
+def with_session(func):
+    if not inspect.iscoroutinefunction(func):
+        raise TypeError("Database sessions allowed only in async functions")
 
-        assert isinstance(user, User), f"Non-User instance returned by sqlalchemy - {user!r}[{user}]"
+    @wraps(func)
+    async def wrapper(*args, **kwargs):
+        async with get_session() as session:
+            return await func(session, *args, **kwargs)
 
-        print(f"New login to user with ID {user_id} - {user.nickname} from address {address}")
-        print(f"Tokens count {len(user.tokens)}")
+    return wrapper
+
+
+@dramatiq.actor(max_retries=3)
+@with_session
+async def new_login(session: AsyncSession, user_id: int, address: str, agent: str | None):
+    from src.models import User, Token
+    from src.util import now
+
+    now = now()
+
+    agent_data = user_agent_parser.Parse(agent)
+
+    user = await session.get(User, user_id, options=(joinedload(User.tokens),))
+
+    assert isinstance(user, User), f"Non-User instance returned by sqlalchemy - {user!r}[{user}]"
+
+    write("NEW LOGIN")
+    write("Address:", address)
+    write(f"OS:", agent_data["os"])
+    write(f"Device:", agent_data["device"])
+    write(f"Client:", agent_data["user_agent"])
+    write("User:", user.id, "Nickname:", user.nickname)
+    write("Tokens count:", len(user.tokens))
+
+    older_and_active_tokens = await session.scalars(
+        select(Token).filter(
+            Token.created_at <= now - timedelta(hours=24),
+            Token.expire_at > now,
+            Token.owner_id == user_id,
+        )
+    )
+
+    # There should be logic for sending notification to specific tokens about actions
+    for token in older_and_active_tokens:
+        write(f"Notifying token {token.id} about new login")
+
+    write("NEW LOGIN END")
+
+
+@dramatiq.actor
+@with_session
+async def user_nickname_updated(session: AsyncSession, user_id: str, before: str, after: str, updated_by: int | None = None) -> None:
+    from src.models import User
+    user = await session.get(User, user_id)
+
+    # There should be logic to save up to 10 nickname changes per user
+    write("USER NICKNAME UPDATE")
+    write("User:", user.id, "Nickname:", user.nickname)
+    write("Before:", before)
+    write("After:", after)
+    write("Updated by:", updated_by)
+    write("USER NICKNAME UPDATE END")


### PR DESCRIPTION
This PR migrates the project from using ``celery`` to ``dramatiq``, which natively supports ``asyncio``.

Also:
- Adds user-agent to ``ClientInfo`` to provide more clear information about new logins
- Adds task that in future should save up to 10 user's nickname changes to its history